### PR TITLE
Remove rexml from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ source "http://rubygems.org"
 # gem 'aws-sdk-cloudwatch', '~> 1.80'
 gem "aws-sdk-dynamodb", "~> 1.93", ">= 1.93.1"
 
-# maintain compatibility with 3.5.0 as released
-gem "rexml", "~> 3.2", ">= 3.2.5", "< 3.2.9"
-
 group :development do
   gem "standard"
 end


### PR DESCRIPTION
Recent compatibility issues have been addressed from 3.3.0:

https://github.com/ruby/rexml/commit/31738ccfc3324f4b32769fa1695c78c06a88c277
